### PR TITLE
Spread ALL_MARKDOWN_TRANSFORMERS in markdownExt config

### DIFF
--- a/apps/web/components/templates/default/DefaultTemplate.tsx
+++ b/apps/web/components/templates/default/DefaultTemplate.tsx
@@ -58,7 +58,7 @@ type TableConfig = {
 
 // Create markdown extension instance
 const markdownExt = new MarkdownExtension().configure({
-  customTransformers: ALL_MARKDOWN_TRANSFORMERS,
+  customTransformers: [...ALL_MARKDOWN_TRANSFORMERS],
 });
 
 // Define extensions array


### PR DESCRIPTION
fixed the issue to allow ALL_MARKDOWN_TRANSFORMERS acutally get loaded into the markdown extension and allow things like imageNodes to be properly fixed